### PR TITLE
improvements as pre-commit-hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,3 +8,4 @@
   additional_dependencies:
     - czespressif
   require_serial: true
+  stages: [pre-push]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,9 +1,10 @@
 ---
 - id: update-changelog
-  name: Update changelog (section Unreleased)
-  entry: python -c 'import subprocess; subprocess.run("cz changelog > /dev/null", shell=True, check=True)'
+  name: update-changelog
+  description: Update changelog (section Unreleased)
+  entry: cz changelog --incremental
   language: python
   pass_filenames: false
-  description: Updates changelog - section Unreleased
   additional_dependencies:
     - czespressif
+  require_serial: true

--- a/README.md
+++ b/README.md
@@ -370,7 +370,6 @@ To automatically keep your changelog's "Unreleased" section up to date, add the 
   rev: ''
   hooks:
     - id: update-changelog
-      files: ^pyproject\.toml$ # Runs only if file with version changes
 ```
 
 Next, run the following command to fetch the latest version (`rev:`):
@@ -378,6 +377,14 @@ Next, run the following command to fetch the latest version (`rev:`):
 ```sh
 pre-commit autoupdate --repo https://github.com/espressif/cz-plugin-espressif
 ```
+
+If you have already set `default_install_hook_types`, then include `pre-push` in the list. Otherwise, add the following to your `.pre-commit-config.yaml` file:
+
+```yaml
+default_install_hook_types: [pre-commit, pre-push]
+```
+
+After installing the hook, it runs automatically before you pushing commits to the repository. It updates the changelog with the latest commits. If the push failed because of the hook, don't forget to add the updated changelog to the commit and push again.
 
 ---
 


### PR DESCRIPTION
### HEAD~1

User may now use

```
  - repo: https://github.com/espressif/cz-plugin-espressif
    rev: fix/pre-commit-entry
    hooks:
      - id: update-changelog
```

to make changelog generated incrementally

---

### HEAD

User may now install the hook to `pre-push` stage, and update the changelog before pushing the branch