### PR TITLE
ci(dependabot): update settings, interval for non-security updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: pip
     versioning-strategy: increase-if-necessary
     directory: '/'
-    schedule: {interval: weekly, day: monday, time: '05:00', timezone: Europe/Prague}
+    schedule: {interval: monthly}
     groups:
       pip-security-updates:
         applies-to: security-updates
@@ -32,7 +32,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: '/'
-    schedule: {interval: weekly, day: monday, time: '05:00', timezone: Europe/Prague}
+    schedule: {interval: monthly}
     groups:
       github-actions-security-updates:
         applies-to: security-updates


### PR DESCRIPTION
Reduces interval for checking non-security updates once per month (1st day in month).
Current settings (weekly) creates lot of PR / JIRA tasks, that are not necessary.