### PR TITLE
fix(changelog): fix logo link in changelog header

### DIFF
--- a/czespressif/defaults.py
+++ b/czespressif/defaults.py
@@ -90,7 +90,7 @@ TYPES: list[dict] = [  # this is order in changelog
 
 CHANGELOG_TITLE: str = """
 <a href="https://www.espressif.com">
-    <img src="czespressif/templates/espressif-logo.svg" align="right" height="20" />
+    <img src="https://www.espressif.com/sites/all/themes/espressif/logo-black.svg" align="right" height="20" />
 </a>
 
 # CHANGELOG

--- a/tests/__snapshots__/test_changelog/test_changelog_czespressif_full.md
+++ b/tests/__snapshots__/test_changelog/test_changelog_czespressif_full.md
@@ -1,5 +1,5 @@
 <a href="https://www.espressif.com">
-    <img src="czespressif/templates/espressif-logo.svg" align="right" height="20" />
+    <img src="https://www.espressif.com/sites/all/themes/espressif/logo-black.svg" align="right" height="20" />
 </a>
 
 # CHANGELOG

--- a/tests/__snapshots__/test_changelog/test_changelog_czespressif_full_no_emoji.md
+++ b/tests/__snapshots__/test_changelog/test_changelog_czespressif_full_no_emoji.md
@@ -1,5 +1,5 @@
 <a href="https://www.espressif.com">
-    <img src="czespressif/templates/espressif-logo.svg" align="right" height="20" />
+    <img src="https://www.espressif.com/sites/all/themes/espressif/logo-black.svg" align="right" height="20" />
 </a>
 
 # CHANGELOG


### PR DESCRIPTION
## Description

Replaced link for Espressif corner logo in Changelog

Before:
<img src="https://github.com/user-attachments/assets/236a4833-2625-4619-843a-59de54083db6" width="500"/>

After:
<img src="https://github.com/user-attachments/assets/50145260-f6a2-467f-88fe-910cba5cc1cb" width="500"/>
