### PR TITLE
ci(github-actions): update macOS runners (GitHub changed numbering)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -100,7 +100,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        os: [macos-12, macos-14] # macOS 12 (Intel),macOS 14 (Apple Silicon)
+        os: [macos-13, macos-lastest] # macOS 13 (Intel),macOS-latest (Apple Silicon)
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

GitHub changed labeling of macos runners:
- MacOS with Intel chip was `macos-12` -> after change `macos-13`

## Related
- https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
- failed release action: https://github.com/espressif/cz-plugin-espressif/actions/runs/12744219926
