### PR TITLE
fix: Use original path for BaseConfig import

### DIFF
--- a/czespressif/czespressif.py
+++ b/czespressif/czespressif.py
@@ -7,8 +7,8 @@ from collections import OrderedDict
 from collections.abc import Iterable
 from typing import Any
 
+from commitizen.config import BaseConfig
 from commitizen.cz.base import BaseCommitizen
-from commitizen.cz.base import BaseConfig
 from commitizen.defaults import Questions
 from jinja2 import PackageLoader
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@
 
     dependencies               = ["commitizen>=3.29.0"]
     optional-dependencies.dev  = ["just-bin>=1.26.0", "pre-commit>=4.0.1", "twine>=5.1.1"]
-    optional-dependencies.test = ["pytest-cov>=4.1.0", "pytest-mock>=3.14.0", "pytest-sugar>=1.0.0", "pytest>=7.4.0", "syrupy>=4.7.0"]
+    optional-dependencies.test = ["pytest-cov>=4.1.0", "pytest-mock>=3.14.0", "pytest-sugar>=1.0.0", "pytest>=7.4.0", "syrupy>=4.7.0,<5.0"]
 
 [tool]
     [tool.setuptools]

--- a/tests/__snapshots__/test_changelog/test_changelog_cz_default_full.md
+++ b/tests/__snapshots__/test_changelog/test_changelog_cz_default_full.md
@@ -12,15 +12,13 @@
 
 ## v1.2.0 (2024-07-15)
 
-### Refactor
-
-- optimize database queries for user data retrieval
-
-## v1.2.0.rc0 (2024-06-10)
-
 ### Fix
 
 - **frontend**: correct layout issues in user profile page
+
+### Refactor
+
+- optimize database queries for user data retrieval
 
 ## v1.1.0 (2024-05-23)
 

--- a/tests/__snapshots__/test_changelog/test_changelog_czespressif_full.md
+++ b/tests/__snapshots__/test_changelog/test_changelog_czespressif_full.md
@@ -36,14 +36,6 @@
 
 ## v1.2.0 (2024-07-15)
 
-### 🔧 Code Refactoring
-
-- optimize database queries for user data retrieval *(Charlie Green - e7c1d8b)*
-
----
-
-## v1.2.0.rc0 (2024-06-10)
-
 ### 🐛 Bug Fixes
 
 - **frontend**: correct layout issues in user profile page *(Bob Smith - c3e7b3b)*
@@ -51,6 +43,10 @@
 ### 📖 Documentation
 
 - update API documentation for user endpoint *(Eve Martin - f8d7e1c)*
+
+### 🔧 Code Refactoring
+
+- optimize database queries for user data retrieval *(Charlie Green - e7c1d8b)*
 
 ---
 
@@ -108,7 +104,7 @@
             <a href="https://www.github.com/espressif/cz-plugin-espressif">Commitizen Espressif plugin</a>
         </b>
     <br>
-        <sup><a href="https://www.espressif.com">Espressif Systems CO LTD. (2025)</a><sup>
+        <sup><a href="https://www.espressif.com">Espressif Systems CO LTD. (2026)</a><sup>
     </small>
 </div>
 

--- a/tests/__snapshots__/test_changelog/test_changelog_czespressif_full_no_emoji.md
+++ b/tests/__snapshots__/test_changelog/test_changelog_czespressif_full_no_emoji.md
@@ -36,14 +36,6 @@
 
 ## v1.2.0 (2024-07-15)
 
-### Code Refactoring
-
-- optimize database queries for user data retrieval *(Charlie Green - e7c1d8b)*
-
----
-
-## v1.2.0.rc0 (2024-06-10)
-
 ### Bug Fixes
 
 - **frontend**: correct layout issues in user profile page *(Bob Smith - c3e7b3b)*
@@ -51,6 +43,10 @@
 ### Documentation
 
 - update API documentation for user endpoint *(Eve Martin - f8d7e1c)*
+
+### Code Refactoring
+
+- optimize database queries for user data retrieval *(Charlie Green - e7c1d8b)*
 
 ---
 
@@ -108,7 +104,7 @@
             <a href="https://www.github.com/espressif/cz-plugin-espressif">Commitizen Espressif plugin</a>
         </b>
     <br>
-        <sup><a href="https://www.espressif.com">Espressif Systems CO LTD. (2025)</a><sup>
+        <sup><a href="https://www.espressif.com">Espressif Systems CO LTD. (2026)</a><sup>
     </small>
 </div>
 


### PR DESCRIPTION
## Description

In commitizen 4.10.1, there was a change where they started using `TYPE_CHECKING` and only importing the modules when needed (see [diff](https://github.com/commitizen-tools/commitizen/commit/1441c3d4b128eb6f11818730b94692dd7496c5dc#diff-acce48958b50788432b1a4e502b1bc0fbf1ffb89a157941868ffac67782bb77bR13)). This unfortunately caused a fail for us as we did not import the BaseConfig class directly,  but we relied on the import in the `cz.base` path. Fixed the path to the proper location of this class.

Please create a new bug fix release once this is merged, thank you!

I also had to update the year in the tests because it was failing (we should think about a better solution here in some follow-up PR)

The next fix was related to the merging of prereleases (release candidates) changelings. This was changed in commitizen 4.4 and now not only `x.y.z-rcX` are merged but also `x.y.z.rcX` (dash vs dot between main version and prerelease). So snapshots had to be updated accordingly.

The last fix was related to syrupy, which seems to have changed the snapshots, and now it is slightly different, which results in errors in the pipeline.

## Related

- Failed pipeline in IDF Monitor: https://github.com/espressif/esp-idf-monitor/actions/runs/20715098191/job/59464985981#step:5:28

## Testing

Tested locally with both older versions (3.29, 4.0) of commitizen and newer ones (4.10, 4.11.1). By running `cz changelog --dry-run`

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
